### PR TITLE
Store Q letter in wikidata_item_id + Disable speakers validation feature

### DIFF
--- a/apps/captain_fact/lib/captain_fact/speakers/speakers.ex
+++ b/apps/captain_fact/lib/captain_fact/speakers/speakers.ex
@@ -26,22 +26,21 @@ defmodule CaptainFact.Speakers do
   end
 
   @doc """
-  Set given speaker `is_user_defined` field to false which will prevent modifications. Also generates a slug.
+  Generate slug or update existing one for `speaker`
   """
-  def validate_speaker(speaker) do
+  def generate_slug(speaker = %Speaker{}) do
     speaker
-    |> Speaker.changeset_validate_speaker()
+    |> Speaker.changeset_generate_slug()
     |> Repo.update()
   end
 
   @doc """
-  Generate slugs for all speakers with `is_user_defined` set to false
+  Generate slugs for all speakers without one
   """
-  def generate_slugs() do
+  def generate_all_slugs() do
     Speaker
-    |> where([s], s.is_user_defined == false and is_nil(s.slug))
+    |> where([s], is_nil(s.slug))
     |> Repo.all()
-    |> Enum.map(&Speaker.changeset_validate_speaker/1)
-    |> Enum.map(&Repo.update/1)
+    |> Enum.map(&generate_slug/1)
   end
 end

--- a/apps/captain_fact/lib/captain_fact_web/channels/video_debate_history_channel.ex
+++ b/apps/captain_fact/lib/captain_fact_web/channels/video_debate_history_channel.ex
@@ -104,7 +104,6 @@ defmodule CaptainFactWeb.VideoDebateHistoryChannel do
       VideoSpeaker.changeset(%VideoSpeaker{speaker_id: speaker.id, video_id: video_id})
 
     Multi.new()
-    |> multi_undelete_speaker(speaker)
     |> Multi.insert(:video_speaker, video_speaker)
     |> Multi.insert(:action_restore, action_restore(user_id, video_id, speaker))
     |> Repo.transaction()
@@ -129,12 +128,5 @@ defmodule CaptainFactWeb.VideoDebateHistoryChannel do
       {:error, _reason} ->
         {:reply, :error, socket}
     end
-  end
-
-  # No need to do nothing if speaker is not user defined (cannot be removed)
-  defp multi_undelete_speaker(multi, %{is_user_defined: false}), do: multi
-
-  defp multi_undelete_speaker(multi, speaker) do
-    Multi.update(multi, :speaker, Speaker.changeset_restore(speaker))
   end
 end

--- a/apps/captain_fact/lib/captain_fact_web/views/speaker_view.ex
+++ b/apps/captain_fact/lib/captain_fact_web/views/speaker_view.ex
@@ -12,7 +12,6 @@ defmodule CaptainFactWeb.SpeakerView do
       full_name: speaker.full_name,
       title: speaker.title,
       picture: DB.Type.SpeakerPicture.url({speaker.picture, speaker}, :thumb),
-      is_user_defined: speaker.is_user_defined,
       country: speaker.country,
       wikidata_item_id: speaker.wikidata_item_id
     }

--- a/apps/captain_fact/test/captain_fact/speakers/speakers_test.exs
+++ b/apps/captain_fact/test/captain_fact/speakers/speakers_test.exs
@@ -1,0 +1,49 @@
+defmodule CaptainFact.SpeakersTest do
+  use CaptainFact.DataCase
+  alias CaptainFact.Speakers
+
+  setup do
+    DB.Repo.delete_all(DB.Schema.Speaker)
+    :ok
+  end
+
+  @full_name "Frank Zappa"
+  @slug "Frank-Zappa"
+  @other_full_name "Frank Zappette"
+  @other_slug "Frank-Zappette"
+
+  describe "generate slug" do
+    test "generates a slug from name" do
+      speaker = insert(:speaker, slug: nil, full_name: @full_name)
+      {:ok, updated_speaker} = Speakers.generate_slug(speaker)
+      assert updated_speaker.slug == @slug
+    end
+
+    test "error if slug already exists" do
+      speaker = insert(:speaker, slug: nil, full_name: @full_name)
+      speaker_duplicate = insert(:speaker, slug: nil, full_name: @full_name)
+      assert {:ok, _} = Speakers.generate_slug(speaker)
+      assert {:error, %Ecto.Changeset{}} = Speakers.generate_slug(speaker_duplicate)
+    end
+
+    test "update slug if already filled" do
+      speaker = insert(:speaker, slug: @slug, full_name: @other_full_name)
+      assert {:ok, updated_speaker} = Speakers.generate_slug(speaker)
+      assert updated_speaker.slug == @other_slug
+    end
+  end
+
+  describe "generate all slugs" do
+    test "generate slugs for speakers with nil slug" do
+      speaker = insert(:speaker, slug: nil, full_name: @full_name)
+      Speakers.generate_all_slugs()
+      assert DB.Repo.get(DB.Schema.Speaker, speaker.id).slug == @slug
+    end
+
+    test "does't update existing slugs" do
+      speaker = insert(:speaker, slug: @slug, full_name: @other_full_name)
+      Speakers.generate_all_slugs()
+      assert DB.Repo.get(DB.Schema.Speaker, speaker.id).slug == @slug
+    end
+  end
+end

--- a/apps/cf_graphql/lib/schema/content_types.ex
+++ b/apps/cf_graphql/lib/schema/content_types.ex
@@ -70,9 +70,6 @@ defmodule CF.GraphQL.Schema.ContentTypes do
     field(:country, :string)
     @desc "Wikidata unique identifier, without the 'Q' prefix"
     field(:wikidata_item_id, :string)
-
-    @desc "True if speaker is user defined (editable), false if it comes from wikidata or has been validated"
-    field(:is_user_defined, non_null(:boolean))
     @desc "Speaker's picture URL. Format is 50x50"
     field(:picture, :string, do: resolve(&Resolvers.Speakers.picture/3))
     @desc "List of speaker's videos"

--- a/apps/cf_graphql/lib/schema/content_types.ex
+++ b/apps/cf_graphql/lib/schema/content_types.ex
@@ -69,7 +69,7 @@ defmodule CF.GraphQL.Schema.ContentTypes do
     @desc "Country code of the speaker's origin (from wikidata)"
     field(:country, :string)
     @desc "Wikidata unique identifier, without the 'Q' prefix"
-    field(:wikidata_item_id, :integer)
+    field(:wikidata_item_id, :string)
 
     @desc "True if speaker is user defined (editable), false if it comes from wikidata or has been validated"
     field(:is_user_defined, non_null(:boolean))

--- a/apps/db/lib/db_schema/speaker.ex
+++ b/apps/db/lib/db_schema/speaker.ex
@@ -9,9 +9,7 @@ defmodule DB.Schema.Speaker do
     field(:slug, :string)
     field(:country, :string)
     field(:wikidata_item_id, :string)
-    field(:is_user_defined, :boolean, default: true)
     field(:picture, DB.Type.SpeakerPicture.Type)
-    field(:is_removed, :boolean, default: false)
 
     has_many(:statements, DB.Schema.Statement, on_delete: :nilify_all)
 
@@ -47,26 +45,11 @@ defmodule DB.Schema.Speaker do
   end
 
   @doc """
-  Builds a deletion changeset for `struct`
+  Builds a changeset to generate speaker slug
   """
-  def changeset_remove(struct) do
-    cast(struct, %{is_removed: true}, [:is_removed])
-  end
-
-  @doc """
-  Builds a restore changeset for `struct`
-  """
-  def changeset_restore(struct) do
-    cast(struct, %{is_removed: false}, [:is_removed])
-  end
-
-  @doc """
-  Builds a changeset to validate speaker, setting user_defined to false and generate a slug
-  """
-  def changeset_validate_speaker(struct = %{full_name: name}) do
+  def changeset_generate_slug(struct = %{full_name: name}) do
     struct
-    |> Ecto.Changeset.change(is_user_defined: false)
-    |> Ecto.Changeset.put_change(:slug, Slugger.slugify(name))
+    |> change(slug: Slugger.slugify(name))
     |> unique_constraint(:slug)
   end
 end

--- a/apps/db/lib/db_schema/speaker.ex
+++ b/apps/db/lib/db_schema/speaker.ex
@@ -8,7 +8,7 @@ defmodule DB.Schema.Speaker do
     field(:title, :string)
     field(:slug, :string)
     field(:country, :string)
-    field(:wikidata_item_id, :integer)
+    field(:wikidata_item_id, :string)
     field(:is_user_defined, :boolean, default: true)
     field(:picture, DB.Type.SpeakerPicture.Type)
     field(:is_removed, :boolean, default: false)
@@ -41,6 +41,8 @@ defmodule DB.Schema.Speaker do
     |> validate_length(:full_name, min: 3, max: 60)
     |> validate_length(:title, min: 3, max: 60)
     |> validate_required(:full_name)
+    |> update_change(:wikidata_item_id, &String.upcase/1)
+    |> validate_format(:wikidata_item_id, ~r/Q[1-9]\d*/)
     |> unique_constraint(:wikidata_item_id)
   end
 

--- a/apps/db/priv/repo/migrations/20180816112748_change_wikidata_item_id_type_to_string.exs
+++ b/apps/db/priv/repo/migrations/20180816112748_change_wikidata_item_id_type_to_string.exs
@@ -1,0 +1,19 @@
+defmodule DB.Repo.Migrations.ChangeWikidataItemIdTypeToString do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    ALTER TABLE speakers
+    ALTER COLUMN wikidata_item_id TYPE character varying(255)
+    USING 'Q' || wikidata_item_id;
+    """)
+  end
+
+  def down do
+    execute("""
+    ALTER TABLE speakers
+    ALTER COLUMN wikidata_item_id TYPE integer
+    USING (substring(wikidata_item_id from 2))::integer;
+    """)
+  end
+end

--- a/apps/db/priv/repo/migrations/20180816115534_remove_speaker_is_user_defined_column.exs
+++ b/apps/db/priv/repo/migrations/20180816115534_remove_speaker_is_user_defined_column.exs
@@ -1,0 +1,39 @@
+defmodule DB.Repo.Migrations.RemoveSpeakerIsUserDefinedColumn do
+  use Ecto.Migration
+
+  def up do
+    # Drop indexes
+    drop(index(:speakers, :full_name))
+    drop(index(:speakers, :wikidata_item_id))
+    drop(unique_index(:speakers, :slug))
+
+    # Remove column
+    alter table(:speakers) do
+      remove(:is_user_defined)
+      remove(:is_removed)
+    end
+
+    # Re-create indexes
+    create index(:speakers, :full_name)
+    create unique_index(:speakers, :wikidata_item_id)
+    create unique_index(:speakers, :slug, where: "slug IS NOT NULL")
+  end
+
+  def down do
+    # Drop indexes
+    drop(index(:speakers, :full_name))
+    drop(index(:speakers, :wikidata_item_id))
+    drop(unique_index(:speakers, :slug))
+
+    # Re-add columns
+    alter table(:speakers) do
+      add(:is_user_defined, :boolean, null: false, default: true)
+      add :is_removed, :boolean, null: false, default: false
+    end
+
+    # Re-create indexes
+    create index(:speakers, :full_name, where: "is_user_defined = false")
+    create unique_index(:speakers, :wikidata_item_id, where: "is_user_defined = false")
+    create unique_index(:speakers, :slug, where: "slug IS NOT NULL")
+  end
+end

--- a/apps/db/priv/repo/seed_politicians.exs
+++ b/apps/db/priv/repo/seed_politicians.exs
@@ -19,7 +19,7 @@ defmodule SeedPoliticians do
     })
   end
 
-  defp get_wikidata_item_id("http://www.wikidata.org/entity/Q" <> id), do: id
+  defp get_wikidata_item_id("http://www.wikidata.org/entity/" <> id), do: id
 
   defp seed_politician_with_picture(changes, names_filter) do
     {picture_url, changes} = Map.pop(changes, :picture)

--- a/apps/db/priv/repo/seed_politicians.exs
+++ b/apps/db/priv/repo/seed_politicians.exs
@@ -35,7 +35,7 @@ defmodule SeedPoliticians do
         |> Map.delete(:picture)
         |> Map.put(:title, "Politician")
 
-      changeset = Speaker.changeset(%Speaker{is_user_defined: false}, changes)
+      changeset = Speaker.changeset(%Speaker{}, changes)
 
       if changeset.valid? do
         case Repo.get_by(Speaker, wikidata_item_id: changeset.changes.wikidata_item_id) do

--- a/apps/db/priv/repo/structure.sql
+++ b/apps/db/priv/repo/structure.sql
@@ -84,7 +84,7 @@ CREATE TABLE comments (
     statement_id integer NOT NULL,
     source_id integer,
     reply_to_id integer,
-    text character varying(255),
+    text character varying(512),
     approve boolean,
     is_reported boolean DEFAULT false NOT NULL,
     inserted_at timestamp without time zone NOT NULL,
@@ -142,6 +142,24 @@ CREATE SEQUENCE flags_id_seq
 --
 
 ALTER SEQUENCE flags_id_seq OWNED BY flags.id;
+
+
+--
+-- Name: guardian_tokens; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE guardian_tokens (
+    jti character varying(255) NOT NULL,
+    aud character varying(255) NOT NULL,
+    typ character varying(255),
+    iss character varying(255),
+    sub character varying(255),
+    exp bigint,
+    jwt text,
+    claims jsonb,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
 
 
 --
@@ -266,14 +284,12 @@ CREATE TABLE speakers (
     id integer NOT NULL,
     full_name citext NOT NULL,
     title character varying(255),
-    is_user_defined boolean NOT NULL,
     picture character varying(255),
-    wikidata_item_id integer,
+    wikidata_item_id character varying(255),
     country character varying(255),
-    is_removed boolean DEFAULT false NOT NULL,
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    slug character varying(255)
+    slug citext
 );
 
 
@@ -613,6 +629,14 @@ ALTER TABLE ONLY flags
 
 
 --
+-- Name: guardian_tokens guardian_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY guardian_tokens
+    ADD CONSTRAINT guardian_tokens_pkey PRIMARY KEY (jti, aud);
+
+
+--
 -- Name: invitation_requests invitation_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -747,21 +771,21 @@ CREATE UNIQUE INDEX sources_url_index ON sources USING btree (url);
 -- Name: speakers_full_name_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX speakers_full_name_index ON speakers USING btree (full_name) WHERE (is_user_defined = false);
+CREATE INDEX speakers_full_name_index ON speakers USING btree (full_name);
 
 
 --
 -- Name: speakers_slug_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX speakers_slug_index ON speakers USING btree (slug) WHERE ((slug)::text <> NULL::text);
+CREATE UNIQUE INDEX speakers_slug_index ON speakers USING btree (slug) WHERE (slug IS NOT NULL);
 
 
 --
 -- Name: speakers_wikidata_item_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX speakers_wikidata_item_id_index ON speakers USING btree (wikidata_item_id) WHERE (is_user_defined = false);
+CREATE UNIQUE INDEX speakers_wikidata_item_id_index ON speakers USING btree (wikidata_item_id);
 
 
 --
@@ -1011,5 +1035,5 @@ ALTER TABLE ONLY votes
 -- PostgreSQL database dump complete
 --
 
-INSERT INTO public."schema_migrations" (version) VALUES (20170118223600), (20170118223631), (20170125235612), (20170206062334), (20170206063137), (20170221035619), (20170309214200), (20170309214307), (20170316233954), (20170428062411), (20170611075306), (20170726224741), (20170730064848), (20170928043353), (20171003220327), (20171003220416), (20171004100258), (20171005001838), (20171005215001), (20171009065840), (20171026222425), (20171105124655), (20171109105152), (20171110040302), (20171110212108), (20171117131508), (20171119075520), (20171205174328), (20180131002547), (20180302024059), (20180317062636), (20180330204602), (20180409035326), (20180503083056), (20180516170544), (20180605085958), (20180605144832), (20180730092029);
+INSERT INTO public."schema_migrations" (version) VALUES (20170118223600), (20170118223631), (20170125235612), (20170206062334), (20170206063137), (20170221035619), (20170309214200), (20170309214307), (20170316233954), (20170428062411), (20170611075306), (20170726224741), (20170730064848), (20170928043353), (20171003220327), (20171003220416), (20171004100258), (20171005001838), (20171005215001), (20171009065840), (20171026222425), (20171105124655), (20171109105152), (20171110040302), (20171110212108), (20171117131508), (20171119075520), (20171205174328), (20180131002547), (20180302024059), (20180317062636), (20180330204602), (20180409035326), (20180503083056), (20180516170544), (20180605085958), (20180605144832), (20180730092029), (20180801105246), (20180802155107), (20180803143819), (20180816112748), (20180816115534);
 

--- a/apps/db/test/db_schema/speaker_test.exs
+++ b/apps/db/test/db_schema/speaker_test.exs
@@ -4,7 +4,8 @@ defmodule DB.Schema.SpeakerTest do
   alias DB.Schema.Speaker
 
   @valid_attrs %{
-    full_name: "#{Faker.Name.first_name()} #{Faker.Name.last_name()}"
+    full_name: "#{Faker.Name.first_name()} #{Faker.Name.last_name()}",
+    wikidata_item_id: nil
   }
   @invalid_attrs %{}
 
@@ -46,5 +47,27 @@ defmodule DB.Schema.SpeakerTest do
       Speaker.changeset(%Speaker{}, Map.put(@valid_attrs, :title, "   King     of the world    "))
 
     assert changeset.changes.title == "King of the world"
+  end
+
+  describe "wikidata item id" do
+    test "reject if bad format" do
+      integer_id = %{@valid_attrs | wikidata_item_id: 42}
+      missing_q = %{@valid_attrs | wikidata_item_id: "42424242"}
+      missing_id = %{@valid_attrs | wikidata_item_id: "Q"}
+
+      assert {:wikidata_item_id, "is invalid"} in errors_on(%Speaker{}, integer_id)
+      assert {:wikidata_item_id, "has invalid format"} in errors_on(%Speaker{}, missing_q)
+      assert {:wikidata_item_id, "has invalid format"} in errors_on(%Speaker{}, missing_id)
+    end
+
+    test "accept correct format and uppercase Q if not already" do
+      valid_uppercase = %{@valid_attrs | wikidata_item_id: "Q42"}
+      assert Speaker.changeset(%Speaker{}, valid_uppercase).valid?
+
+      valid_lowercase = %{@valid_attrs | wikidata_item_id: "q42"}
+      changeset = Speaker.changeset(%Speaker{}, valid_lowercase)
+      assert changeset.valid?
+      assert changeset.changes.wikidata_item_id == "Q42"
+    end
   end
 end

--- a/apps/db/test/support/factory.ex
+++ b/apps/db/test/support/factory.ex
@@ -58,8 +58,7 @@ defmodule DB.Factory do
     %Speaker{
       full_name: Faker.Name.name(),
       title: Faker.Name.title(),
-      country: Faker.Address.country_code(),
-      is_user_defined: Enum.random([true, false])
+      country: Faker.Address.country_code()
     }
   end
 

--- a/rel/docker/release_dev.sh
+++ b/rel/docker/release_dev.sh
@@ -41,7 +41,14 @@ docker build -t ${CF_BUILD_IMAGE} --build-arg MIX_ENV=dev -f Dockerfile.build ..
 # ---- Push ----
 set +e
 
-confirm "Push $CF_REST_API_IMAGE ?" && docker push ${CF_REST_API_IMAGE}
-confirm "Push $CF_GRAPHQL_API_IMAGE ?" && docker push ${CF_GRAPHQL_API_IMAGE}
-confirm "Push $CF_ATOM_FEED_IMAGE ?" && docker push ${CF_ATOM_FEED_IMAGE}
-confirm "Push $CF_OPENGRAPH_IMAGE ?" && docker push ${CF_OPENGRAPH_IMAGE}
+echo "You're about to push:"
+echo "  * ${CF_REST_API_IMAGE}"
+echo "  * ${CF_GRAPHQL_API_IMAGE}"
+echo "  * ${CF_ATOM_FEED_IMAGE}"
+echo "  * ${CF_OPENGRAPH_IMAGE}"
+confirm "==> Are you sure?"
+
+docker push ${CF_REST_API_IMAGE}
+docker push ${CF_GRAPHQL_API_IMAGE}
+docker push ${CF_ATOM_FEED_IMAGE}
+docker push ${CF_OPENGRAPH_IMAGE}


### PR DESCRIPTION
This feature is not done yet. However the two firsts parts are already interesting to merge:
* [Store `Q` letter in wikidata_item_id](https://trello.com/c/UsiZ3ukH/742-store-q-letter-in-wikidataitemid)
* [Disable speakers validation feature](https://trello.com/c/UsiZ3ukH/742-store-q-letter-in-wikidataitemid)

Related to https://github.com/CaptainFact/captain-fact-frontend/pull/192