### PR TITLE
Add ability to import captions from YouTube

### DIFF
--- a/apps/captain_fact/config/config.exs
+++ b/apps/captain_fact/config/config.exs
@@ -58,6 +58,9 @@ config :captain_fact, CaptainFact.Authenticator.Guardian,
   serializer: CaptainFact.Accounts.GuardianSerializer,
   permissions: %{default: [:read, :write]}
 
+config :captain_fact,
+  captions_fetcher: CaptainFact.Videos.CaptionsFetcherYoutube
+
 config :guardian, Guardian.DB, repo: DB.Repo
 
 config :weave,

--- a/apps/captain_fact/config/test.exs
+++ b/apps/captain_fact/config/test.exs
@@ -30,3 +30,7 @@ config :captain_fact, CaptainFactMailer, adapter: Bamboo.TestAdapter
 
 # Reduce the number of round for encryption during tests
 config :bcrypt_elixir, :log_rounds, 4
+
+# Captions mock for testing
+config :captain_fact,
+  captions_fetcher: CaptainFact.Videos.CaptionsFetcherTest

--- a/apps/captain_fact/lib/captain_fact/videos/captions_fetcher.ex
+++ b/apps/captain_fact/lib/captain_fact/videos/captions_fetcher.ex
@@ -1,0 +1,8 @@
+defmodule CaptainFact.Videos.CaptionsFetcher do
+  @moduledoc """
+  Fetch captions for videos.
+  """
+
+  @callback fetch(String.t(), String.t()) ::
+              {:ok, DB.Schema.VideoCaption.t()} | {:error, binary()}
+end

--- a/apps/captain_fact/lib/captain_fact/videos/captions_fetcher_test.ex
+++ b/apps/captain_fact/lib/captain_fact/videos/captions_fetcher_test.ex
@@ -1,0 +1,17 @@
+defmodule CaptainFact.Videos.CaptionsFetcherTest do
+  @moduledoc """
+  A mock for faking captions fetching requests.
+  """
+
+  @behaviour CaptainFact.Videos.CaptionsFetcher
+
+  @impl true
+  def fetch(_provider_id, _locale) do
+    captions = %DB.Schema.VideoCaption{
+      content: "__TEST-CONTENT__",
+      format: "xml"
+    }
+
+    {:ok, captions}
+  end
+end

--- a/apps/captain_fact/lib/captain_fact/videos/captions_fetcher_youtube.ex
+++ b/apps/captain_fact/lib/captain_fact/videos/captions_fetcher_youtube.ex
@@ -1,0 +1,38 @@
+defmodule CaptainFact.Videos.CaptionsFetcherYoutube do
+  @moduledoc """
+  A captions fetcher for YouTube.
+  """
+
+  @behaviour CaptainFact.Videos.CaptionsFetcher
+
+  @impl true
+  def fetch(youtube_id, locale) do
+    with {:ok, content} <- fetch_captions_content(youtube_id, locale) do
+      captions = %DB.Schema.VideoCaption{
+        content: content,
+        format: "xml"
+      }
+
+      {:ok, captions}
+    end
+  end
+
+  defp fetch_captions_content(video_id, locale) do
+    case HTTPoison.get("http://video.google.com/timedtext?lang=#{locale}&v=#{video_id}") do
+      {:ok, %HTTPoison.Response{status_code: 200, body: ""}} ->
+        {:error, :not_found}
+
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        {:ok, body}
+
+      {:ok, %HTTPoison.Response{status_code: 404}} ->
+        {:error, :not_found}
+
+      {:ok, %HTTPoison.Response{status_code: _}} ->
+        {:error, :unknown}
+
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:error, reason}
+    end
+  end
+end

--- a/apps/captain_fact/test/captain_fact/videos/videos_test.exs
+++ b/apps/captain_fact/test/captain_fact/videos/videos_test.exs
@@ -56,4 +56,13 @@ defmodule CaptainFact.VideosTest do
       assert video.hash_id == VideoHashId.encode(video.id)
     end
   end
+
+  describe "Fetch captions" do
+    test "fetch captions" do
+      video = DB.Factory.insert(:video, provider: "__TEST__")
+      {:ok, captions} = Videos.download_captions(video)
+
+      assert captions.content == "__TEST-CONTENT__"
+    end
+  end
 end

--- a/apps/db/lib/db_schema/video_caption.ex
+++ b/apps/db/lib/db_schema/video_caption.ex
@@ -1,0 +1,24 @@
+defmodule DB.Schema.VideoCaption do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  schema "videos_captions" do
+    belongs_to(:video, DB.Schema.Video, primary_key: true)
+    field(:content, :string)
+    field(:format, :string)
+
+    timestamps()
+  end
+
+  @required_fields ~w(video_id content format)a
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @required_fields)
+    |> validate_required(@required_fields)
+  end
+end

--- a/apps/db/priv/repo/migrations/20181010105152_create_video_captions.exs
+++ b/apps/db/priv/repo/migrations/20181010105152_create_video_captions.exs
@@ -1,0 +1,14 @@
+defmodule DB.Repo.Migrations.CreateVideoCaptions do
+  use Ecto.Migration
+
+  def change do
+    create table(:videos_captions) do
+      add(:video_id, references(:videos, on_delete: :delete_all))
+      add(:content, :text, null: false)
+      add(:format, :string, null: false)
+      timestamps()
+    end
+
+    create(index(:videos_captions, [:video_id]))
+  end
+end


### PR DESCRIPTION
Hi 👋  I've taken a stab at #11. I'm starting with Elixir and look for feedback on my code.

Unfortunately the solution the issue described didn't work out because YouTube doesn't grant access to download captions like that. See this [StackOverflow question](https://stackoverflow.com/questions/46864428/how-do-some-sites-download-youtube-captions).

I used the solution proposed in the StackOverflow answer, to call `http://video.google.com/timedtext?lang={LANG}&v={VIDEOID}`. What do you think? 

The caption is in XML format which might be handy to keep (timings are in there too). [Example](http://video.google.com/timedtext?lang=fr&v=d-4KQbG2REA).


