### PR TITLE
Add ability to login using email or username alike

### DIFF
--- a/apps/captain_fact/lib/captain_fact/authenticator/authenticator.ex
+++ b/apps/captain_fact/lib/captain_fact/authenticator/authenticator.ex
@@ -2,6 +2,7 @@ defmodule CaptainFact.Authenticator do
   @moduledoc """
   Handle all authentication intelligence
   """
+  import Ecto.Query
 
   alias DB.Repo
   alias DB.Schema.User
@@ -10,11 +11,16 @@ defmodule CaptainFact.Authenticator do
   alias Kaur.Result
 
   @doc """
-  Get user from its email address and check password.
+  Get user from its email address or user name and check password.
   Returns nil if no User for email or if password is invalid.
   """
-  def get_user_for_email_password(email, password) do
-    with user when not is_nil(user) <- Repo.get_by(User, email: email),
+  def get_user_for_email_or_name_password(email_or_name, password) do
+    user =
+      User
+      |> where([u], u.email == ^email_or_name or u.username == ^email_or_name)
+      |> Repo.one()
+
+    with user when not is_nil(user) <- user,
          true <- validate_pass(user.encrypted_password, password) do
       user
     else

--- a/apps/captain_fact/lib/captain_fact_web/controllers/auth_controller.ex
+++ b/apps/captain_fact/lib/captain_fact_web/controllers/auth_controller.ex
@@ -22,10 +22,10 @@ defmodule CaptainFactWeb.AuthController do
   @err_invalid_email_password "invalid_email_password"
 
   @doc """
-  Auth with identity (email + password)
+  Auth with identity (name|email + password)
   """
   def callback(conn, %{"provider" => "identity", "email" => email, "password" => password}) do
-    case Authenticator.get_user_for_email_password(email, password) do
+    case Authenticator.get_user_for_email_or_name_password(email, password) do
       nil ->
         conn
         |> put_status(:unauthorized)

--- a/apps/captain_fact/test/captain_fact/authenticator/authenticator_test.exs
+++ b/apps/captain_fact/test/captain_fact/authenticator/authenticator_test.exs
@@ -5,10 +5,20 @@ defmodule CaptainFact.AuthenticatorTest do
   alias CaptainFact.Authenticator
 
   describe "Identity" do
-    test "can login" do
+    test "can login with email" do
       password = "password458"
       user = insert_user_with_custom_password(password)
-      authenticated_user = Authenticator.get_user_for_email_password(user.email, password)
+      authenticated_user = Authenticator.get_user_for_email_or_name_password(user.email, password)
+
+      assert user.id == authenticated_user.id
+    end
+
+    test "can login with name" do
+      password = "password458"
+      user = insert_user_with_custom_password(password)
+
+      authenticated_user =
+        Authenticator.get_user_for_email_or_name_password(user.username, password)
 
       assert user.id == authenticated_user.id
     end
@@ -20,7 +30,7 @@ defmodule CaptainFact.AuthenticatorTest do
       user = insert_user_with_custom_password(password)
 
       check all password <- binary(), max_runs: 3 do
-        assert is_nil(Authenticator.get_user_for_email_password(user.email, password))
+        assert is_nil(Authenticator.get_user_for_email_or_name_password(user.email, password))
       end
     end
   end


### PR DESCRIPTION
To avoid complexity in the frontend, the `email` field is used for
logging in with email or username.

Fixes #9.