### PR TITLE
Disable jobs scheduler in tests

### DIFF
--- a/apps/cf_jobs/config/test.exs
+++ b/apps/cf_jobs/config/test.exs
@@ -1,4 +1,4 @@
 use Mix.Config
 
 # Disable CRON tasks on test
-config :cf_jobs, CF.Scheduler, jobs: []
+config :cf_jobs, CF.Jobs.Scheduler, jobs: []


### PR DESCRIPTION
Jobs scheduler test configuration was invalid, leading to scheduler still trying to run the jobs in test env (thus conflicting the existing tests).

This PR should fix https://github.com/CaptainFact/captain-fact-api/issues/41