### PR TITLE
Adds a method to retrieve actions pending moderation which are actionable by the logged in user.

### DIFF
--- a/apps/cf/test/moderation/moderation_test.exs
+++ b/apps/cf/test/moderation/moderation_test.exs
@@ -1,9 +1,80 @@
 defmodule CF.ModerationTest do
   use CF.DataCase
-  #  import CF.TestUtils, only: [flag_comments: 2]
+
+  import CF.TestUtils, only: [flag_comments: 2]
+
+  alias CF.Moderation
+  alias DB.Schema.UserAction
+
   doctest CF.Moderation
 
   # TODO can only give one feedback
   # TODO cannot give feedback on an action which is not reported
   # TODO Make sure user doesn't get and cannot give feedback on its own actions or actions he's targeted by
+
+  describe "unread_count" do
+    test "no moderation entries if all open actions belong to users" do
+      user = insert(:user, reputation: 1000)
+      limit = max(Moderation.nb_flags_to_report(:create, :comment), 0)
+
+      Enum.each(1..5, fn x ->
+        comment =
+          insert(:comment, %{user: user, text: "Own comment" <> to_string(x)})
+          |> with_action()
+
+        flag_comments([comment], limit)
+      end)
+
+      count = Moderation.unread_count!(user)
+      assert count == 0
+    end
+
+    test "count pending actions from other users" do
+      user = insert(:user, reputation: 1000)
+      limit = Moderation.nb_flags_to_report(:create, :comment)
+
+      comment =
+        insert(:comment, %{user: user, text: "Own comment"})
+        |> with_action()
+
+      flag_comments([comment], limit)
+
+      Enum.each(1..8, fn x ->
+        comment = insert(:comment, %{text: "User comment " <> to_string(x)}) |> with_action()
+        flag_comments([comment], limit)
+        Repo
+      end)
+
+      count = Moderation.unread_count!(user)
+      assert count == 8
+    end
+
+    test "count pending actions from other users, unless already moderated" do
+      user = insert(:user, reputation: 1000)
+      limit = Moderation.nb_flags_to_report(:create, :comment)
+      comment = insert(:comment, %{user: user, text: "Own comment"}) |> with_action()
+      flag_comments([comment], limit)
+
+      Enum.each(1..8, fn x ->
+        comment = insert(:comment, %{text: "User comment" <> to_string(x)}) |> with_action()
+        flag_comments([comment], limit)
+
+        # Produce feedback for two of the actions.
+        if rem(x, 3) == 0 do
+          action =
+            Repo.get_by!(
+              UserAction,
+              entity: :comment,
+              type: :create,
+              comment_id: comment.id
+            )
+
+          Moderation.feedback!(user, action.id, 1, 1)
+        end
+      end)
+
+      count = Moderation.unread_count!(user)
+      assert count == 6
+    end
+  end
 end

--- a/apps/cf_graphql/lib/resolvers/users.ex
+++ b/apps/cf_graphql/lib/resolvers/users.ex
@@ -5,6 +5,8 @@ defmodule CF.Graphql.Resolvers.Users do
 
   import Ecto.Query
 
+  alias CF.Moderation
+
   alias Kaur.Result
 
   alias DB.Repo
@@ -75,6 +77,14 @@ defmodule CF.Graphql.Resolvers.Users do
     |> or_where([a], a.target_user_id == ^user.id and a.type in ^@action_banned)
     |> DB.Query.order_by_last_inserted_desc()
     |> Repo.paginate(page: offset, page_size: limit)
+    |> Result.ok()
+  end
+
+  @doc """
+  Resolve user actions history
+  """
+  def pending_moderations(user, _, _) do
+    Moderation.unread_count!(user)
     |> Result.ok()
   end
 

--- a/apps/cf_graphql/lib/schema/types/user.ex
+++ b/apps/cf_graphql/lib/schema/types/user.ex
@@ -59,6 +59,12 @@ defmodule CF.Graphql.Schema.Types.User do
       resolve(&Resolvers.Notifications.for_user/3)
     end
 
+    @desc "Actions pending moderation"
+    field :actions_pending_moderation, :integer do
+      middleware(Middleware.RequireAuthentication)
+      resolve(&Resolvers.Users.pending_moderations/3)
+    end
+
     @desc "User subscriptions"
     field :subscriptions, list_of(:notifications_subscription) do
       middleware(Middleware.RequireAuthentication)


### PR DESCRIPTION
- Creates a method to fetch the number of actions pending for moderation.
- Add a field in GraphQL to fetch that number.

Addresses CaptainFact/captain-fact#95 backend needs.