### PR TITLE
Video: Don't crash on invalid languages

### DIFF
--- a/apps/db/lib/db_schema/video.ex
+++ b/apps/db/lib/db_schema/video.ex
@@ -155,7 +155,22 @@ defmodule DB.Schema.Video do
     |> unique_constraint(:videos_youtube_id_index)
     |> unique_constraint(:videos_facebook_id_index)
     # Change locales like "en-US" to "en"
-    |> update_change(:language, &hd(String.split(&1, "-")))
+    |> update_change(:language, &format_language/1)
+  end
+
+  defp format_language("zxx"), do: nil
+
+  defp format_language(locale) do
+    cond do
+      is_binary(locale) and locale =~ "-" ->
+        format_language(hd(String.split(locale, "-")))
+
+      is_binary(locale) and String.length(locale) == 2 ->
+        locale
+
+      true ->
+        nil
+    end
   end
 
   @doc """

--- a/apps/db/test/db_schema/video_test.exs
+++ b/apps/db/test/db_schema/video_test.exs
@@ -43,5 +43,29 @@ defmodule DB.Schema.VideoTest do
       attrs = %{title: String.duplicate("x", 121)}
       assert {:title, "should be at most 120 character(s)"} in errors_on(%Video{}, attrs)
     end
+
+    test "unknown or invalid language gives nil values but aren't rejected" do
+      attrs = Map.put(@valid_attrs, :language, "zxx")
+      changeset = Video.changeset(%Video{}, attrs)
+      assert changeset.valid?
+      assert changeset.changes.language == nil
+
+      attrs = Map.put(@valid_attrs, :language, "xxx-zzz-fff")
+      changeset = Video.changeset(%Video{}, attrs)
+      assert changeset.valid?
+      assert changeset.changes.language == nil
+    end
+
+    test "valid locale is stored" do
+      attrs = Map.put(@valid_attrs, :language, "fr")
+      changeset = Video.changeset(%Video{}, attrs)
+      assert changeset.valid?
+      assert changeset.changes.language == "fr"
+
+      attrs = Map.put(@valid_attrs, :language, "en-US")
+      changeset = Video.changeset(%Video{}, attrs)
+      assert changeset.valid?
+      assert changeset.changes.language == "en"
+    end
   end
 end


### PR DESCRIPTION
A quick fix for the crash of adding a new video with `zxx` locale