### PR TITLE
Build & publish docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+      - staging
+
+env:
+  DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+jobs:
+  push-to-docker-hub:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: docker build --build-arg BUILD_ENV=${GITHUB_REF##*/} -t captainfact/api:${GITHUB_REF##*/} .
+      - run: docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+      - run: docker push captainfact/api:${GITHUB_REF##*/}


### PR DESCRIPTION
This feature was removed when we migrated to the latest monolithic deployment approach, but people rely on it for frontend dev (see https://github.com/CaptainFact/captain-fact/issues/218#issuecomment-1370133769).

After this PR we'll need to update `frontend/docker-compose.yml` to adapt to the fact that there's now a single image.