### PR TITLE
Facebook: ignore invalid names

### DIFF
--- a/apps/cf/lib/accounts/accounts.ex
+++ b/apps/cf/lib/accounts/accounts.ex
@@ -59,13 +59,23 @@ defmodule CF.Accounts do
     # Truncate name to avoid crashing when registering with a too-long name
     cond do
       Map.has_key?(params, :name) ->
-        Map.update(params, :name, nil, &String.slice(&1, 0..19))
+        Map.update(params, :name, nil, &format_name/1)
 
       Map.has_key?(params, "name") ->
-        Map.update(params, "name", nil, &String.slice(&1, 0..19))
+        Map.update(params, "name", nil, &format_name/1)
 
       true ->
         params
+    end
+  end
+
+  defp format_name(name) when is_nil(name) or name == "", do: nil
+
+  defp format_name(name) do
+    if String.match?(name, User.name_regex()) do
+      String.slice(name, 0..19)
+    else
+      nil
     end
   end
 

--- a/apps/cf/test/accounts/accounts_test.exs
+++ b/apps/cf/test/accounts/accounts_test.exs
@@ -169,6 +169,13 @@ defmodule CF.AccountsTest do
       assert user.name == "abcdefghijklmnopqrst"
     end
 
+    test "ignores name if format is invalid" do
+      user_params = Map.put(build_user_params(), :name, "🥀🥀'🥀'🥀'🥀")
+      provider_params = %{fb_user_id: "4242424242"}
+      {:ok, user} = Accounts.create_account(user_params, nil, provider_params: provider_params)
+      assert user.name == nil
+    end
+
     test "delete invitation request after creating the user" do
       Repo.delete_all(DB.Schema.InvitationRequest)
       invit = insert(:invitation_request)

--- a/apps/db/lib/db_schema/user.ex
+++ b/apps/db/lib/db_schema/user.ex
@@ -69,6 +69,7 @@ defmodule DB.Schema.User do
     do: "Deleted account"
 
   @email_regex ~r/\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
+  @name_regex ~r/^[^0-9!*();:@&=+$,\/?#\[\].\'\\]+$/i
   @valid_locales ~w(en fr)
   @required_fields ~w(email username)a
   @optional_fields ~w(name password locale)a
@@ -191,6 +192,8 @@ defmodule DB.Schema.User do
     change(model, completed_onboarding_steps: [])
   end
 
+  def name_regex(), do: @name_regex
+
   @token_length 32
   defp generate_email_verification_token(changeset, false),
     do:
@@ -216,7 +219,7 @@ defmodule DB.Schema.User do
     |> validate_email()
     |> validate_locale()
     |> validate_username()
-    |> validate_format(:name, ~r/^[^0-9!*();:@&=+$,\/?#\[\].\'\\]+$/)
+    |> validate_format(:name, @name_regex)
   end
 
   defp put_encrypted_pw(changeset) do


### PR DESCRIPTION
Fix https://github.com/CaptainFact/captain-fact/issues/34

For users registering through Facebook with invalid names, we'll simply omit the field.